### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildx-oneshot.yml
+++ b/.github/workflows/buildx-oneshot.yml
@@ -2,7 +2,11 @@ name: buildx
 
 on:
   workflow_dispatch:
-  
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pyrlscan/security/code-scanning/1](https://github.com/deadjdona/pyrlscan/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are appropriate:

- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to DockerHub.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `docker` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
