### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pyrlscan/security/code-scanning/2](https://github.com/deadjdona/pyrlscan/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
1. The `actions/checkout@v3` and `actions/setup-dotnet@v3` steps likely require `contents: read` to access the repository's code.
2. The `microsoft/security-devops-action@v1.6.0` step may require additional permissions, but this is not explicitly documented. For now, we assume it does not require write permissions.
3. The `github/codeql-action/upload-sarif@v2` step uploads SARIF files, which may require `security-events: write`.

The permissions block will be added at the workflow level to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
