### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -161,6 +161,8 @@ jobs:
   neuralegion_scan:
     runs-on: ubuntu-18.04
     name: A job to run a Nexploit scan
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Start Nexploit Scan 🏁


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pyrlscan/security/code-scanning/10](https://github.com/deadjdona/pyrlscan/security/code-scanning/10)

To address the issue, we will add a `permissions` block to the workflow. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for basic CI workflows and scanning tasks. This change will be applied at the job level (`neuralegion_scan`) to ensure the permissions are scoped appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
