### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/pyrlscan/security/code-scanning/3](https://github.com/deadjdona/pyrlscan/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only requires read access to the repository contents (to analyze Python files with pylint), we can set `contents: read` as the minimal permission. This ensures the workflow operates securely without unnecessary privileges.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
